### PR TITLE
fix: reset output hash length to 5

### DIFF
--- a/packages/beacon-core/src/utils/get-sender-id.ts
+++ b/packages/beacon-core/src/utils/get-sender-id.ts
@@ -13,7 +13,7 @@ export const getSenderId = async (publicKey: string): Promise<string> => {
   if (data.length !== 32) {
     throw new Error('getSenderId: invalid public key length')
   }
-  const buffer = Buffer.from(blake2b(data, undefined, 16))
+  const buffer = Buffer.from(blake2b(data, undefined, 5))
 
   return bs58check.encode(buffer)
 }


### PR DESCRIPTION
## Summary

Some version of Beacon expect the out length of `getSenderId` to be 5. Dapps break otherwise.